### PR TITLE
iscsi-isert, srpt build on RHEL/Centos 7.3 (kernel >= 3.10.0-514.2.2)

### DIFF
--- a/iscsi-scst/kernel/isert-scst/iser.h
+++ b/iscsi-scst/kernel/isert-scst/iser.h
@@ -99,7 +99,10 @@ struct isert_wr {
 	struct ib_sge		*sge_list;
 	union {
 		struct ib_recv_wr recv_wr;
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0) || defined(MOFED_MAJOR)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0) && \
+	(defined(RHEL_RELEASE_CODE) && \
+	RHEL_RELEASE_CODE <= RHEL_RELEASE_VERSION(7,2)) || \
+	defined(MOFED_MAJOR)
 		struct ib_send_wr send_wr;
 #else
 		struct ib_rdma_wr send_wr;

--- a/iscsi-scst/kernel/isert-scst/iser_buf.c
+++ b/iscsi-scst/kernel/isert-scst/iser_buf.c
@@ -238,7 +238,10 @@ int isert_wr_init(struct isert_wr *wr,
 			buff_offset = -EFAULT;
 			goto out;
 		}
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0) || defined(MOFED_MAJOR)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0) && \
+	(defined(RHEL_RELEASE_CODE) && \
+	RHEL_RELEASE_CODE <= RHEL_RELEASE_VERSION(7,2)) || \
+	defined(MOFED_MAJOR)
 		wr->send_wr.wr.rdma.remote_addr = pdu->rem_write_va +
 						  buff_offset;
 		wr->send_wr.wr.rdma.rkey = pdu->rem_write_stag;
@@ -255,7 +258,10 @@ int isert_wr_init(struct isert_wr *wr,
 			buff_offset = -EFAULT;
 			goto out;
 		}
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0) || defined(MOFED_MAJOR)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0) && \
+	(defined(RHEL_RELEASE_CODE) && \
+	RHEL_RELEASE_CODE <= RHEL_RELEASE_VERSION(7,2)) || \
+	defined(MOFED_MAJOR)
 		wr->send_wr.wr.rdma.remote_addr = pdu->rem_read_va +
 						  buff_offset;
 		wr->send_wr.wr.rdma.rkey = pdu->rem_read_stag;
@@ -288,7 +294,10 @@ int isert_wr_init(struct isert_wr *wr,
 		wr->recv_wr.sg_list = wr->sge_list;
 		wr->recv_wr.num_sge = sg_cnt;
 	} else {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0) || defined(MOFED_MAJOR)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0) && \
+	(defined(RHEL_RELEASE_CODE) && \
+	RHEL_RELEASE_CODE <= RHEL_RELEASE_VERSION(7,2)) || \
+	defined(MOFED_MAJOR)
 		wr->send_wr.next = NULL;
 		wr->send_wr.wr_id = _ptr_to_u64(wr);
 		wr->send_wr.sg_list = wr->sge_list;

--- a/iscsi-scst/kernel/isert-scst/iser_pdu.c
+++ b/iscsi-scst/kernel/isert-scst/iser_pdu.c
@@ -214,7 +214,10 @@ out:
 static inline void isert_link_send_wrs(struct isert_wr *from_wr,
 				       struct isert_wr *to_wr)
 {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0) || defined(MOFED_MAJOR)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0) && \
+	(defined(RHEL_RELEASE_CODE) && \
+	RHEL_RELEASE_CODE <= RHEL_RELEASE_VERSION(7,2)) || \
+	defined(MOFED_MAJOR)
 	from_wr->send_wr.next = &to_wr->send_wr;
 #else
 	from_wr->send_wr.wr.next = &to_wr->send_wr.wr;
@@ -226,7 +229,10 @@ static inline void isert_link_send_pdu_wrs(struct isert_cmnd *from_pdu,
 					   int wr_cnt)
 {
 	isert_link_send_wrs(&from_pdu->wr[wr_cnt - 1], &to_pdu->wr[0]);
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0) || defined(MOFED_MAJOR)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0) && \
+	(defined(RHEL_RELEASE_CODE) && \
+	RHEL_RELEASE_CODE <= RHEL_RELEASE_VERSION(7,2)) || \
+	defined(MOFED_MAJOR)
 	to_pdu->wr[0].send_wr.next = NULL;
 #else
 	to_pdu->wr[0].send_wr.wr.next = NULL;
@@ -289,7 +295,10 @@ int isert_prepare_rdma(struct isert_cmnd *isert_pdu,
 		isert_link_send_wrs(&isert_pdu->wr[i - 1], &isert_pdu->wr[i]);
 
 	if (op == ISER_WR_RDMA_READ) {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0) || defined(MOFED_MAJOR)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0) && \
+	(defined(RHEL_RELEASE_CODE) && \
+	RHEL_RELEASE_CODE <= RHEL_RELEASE_VERSION(7,2)) || \
+	defined(MOFED_MAJOR)
 		isert_pdu->wr[wr_cnt - 1].send_wr.send_flags = IB_SEND_SIGNALED;
 		isert_pdu->wr[wr_cnt - 1].send_wr.next = NULL;
 #else
@@ -588,7 +597,10 @@ int isert_pdu_send(struct isert_connection *isert_conn,
 #endif
 
 	wr = &tx_pdu->wr[0];
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0) || defined(MOFED_MAJOR)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0) && \
+	(defined(RHEL_RELEASE_CODE) && \
+	RHEL_RELEASE_CODE <= RHEL_RELEASE_VERSION(7,2)) || \
+	defined(MOFED_MAJOR)
 	wr->send_wr.num_sge = isert_pdu_prepare_send(isert_conn, tx_pdu);
 #else
 	wr->send_wr.wr.num_sge = isert_pdu_prepare_send(isert_conn, tx_pdu);
@@ -613,7 +625,10 @@ int isert_pdu_post_rdma_write(struct isert_connection *isert_conn,
 
 	TRACE_ENTRY();
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0) || defined(MOFED_MAJOR)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0) && \
+	(defined(RHEL_RELEASE_CODE) && \
+	RHEL_RELEASE_CODE <= RHEL_RELEASE_VERSION(7,2)) || \
+	defined(MOFED_MAJOR)
 	isert_rsp->wr[0].send_wr.num_sge = isert_pdu_prepare_send(isert_conn,
 								  isert_rsp);
 #else

--- a/iscsi-scst/kernel/isert-scst/iser_rdma.c
+++ b/iscsi-scst/kernel/isert-scst/iser_rdma.c
@@ -111,7 +111,10 @@ int isert_post_send(struct isert_connection *isert_conn,
 		    struct isert_wr *first_wr,
 		    int num_wr)
 {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0) || defined(MOFED_MAJOR)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0) && \
+	(defined(RHEL_RELEASE_CODE) && \
+	RHEL_RELEASE_CODE <= RHEL_RELEASE_VERSION(7,2)) || \
+	defined(MOFED_MAJOR)
 	struct ib_send_wr *first_ib_wr = &first_wr->send_wr;
 #else
 	struct ib_send_wr *first_ib_wr = &first_wr->send_wr.wr;
@@ -150,7 +153,10 @@ static void isert_post_drain_sq(struct isert_connection* isert_conn)
 
 	isert_wr_set_fields(drain_wr_sq, isert_conn, NULL);
 	drain_wr_sq->wr_op = ISER_WR_SEND;
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0) || defined(MOFED_MAJOR)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0) && \
+	(defined(RHEL_RELEASE_CODE) && \
+	RHEL_RELEASE_CODE <= RHEL_RELEASE_VERSION(7,2)) || \
+	defined(MOFED_MAJOR)
 	drain_wr_sq->send_wr.wr_id = _ptr_to_u64(drain_wr_sq);
 	drain_wr_sq->send_wr.opcode = IB_WR_SEND;
 	err = ib_post_send(isert_conn->qp,
@@ -703,7 +709,10 @@ static void isert_handle_wc_error(struct ib_wc *wc)
 
 	switch (wr->wr_op) {
 	case ISER_WR_SEND:
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0) || defined(MOFED_MAJOR)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0) && \
+	(defined(RHEL_RELEASE_CODE) && \
+	RHEL_RELEASE_CODE <= RHEL_RELEASE_VERSION(7,2)) || \
+	defined(MOFED_MAJOR)
 		num_sge = wr->send_wr.num_sge;
 #else
 		num_sge = wr->send_wr.wr.num_sge;
@@ -968,7 +977,10 @@ static struct isert_device *isert_device_create(struct ib_device *ib_dev)
 		goto out;
 	}
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0) || defined(MOFED_MAJOR)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0) && \
+	(defined(RHEL_RELEASE_CODE) && \
+	RHEL_RELEASE_CODE <= RHEL_RELEASE_VERSION(7,2)) || \
+	defined(MOFED_MAJOR)
 	err = ib_query_device(ib_dev, &isert_dev->device_attr);
 	if (unlikely(err)) {
 		PRINT_ERROR("Failed to query device, err: %d", err);
@@ -1790,7 +1802,10 @@ struct isert_portal *isert_portal_create(void)
 #if LINUX_VERSION_CODE < KERNEL_VERSION(3, 0, 0) && \
 	(!defined(RHEL_MAJOR) || RHEL_MAJOR -0 <= 5)
 	cm_id = rdma_create_id(isert_cm_evt_handler, portal, RDMA_PS_TCP);
-#elif LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0) || defined(MOFED_MAJOR)
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0) && \
+	(defined(RHEL_RELEASE_CODE) && \
+	RHEL_RELEASE_CODE <= RHEL_RELEASE_VERSION(7,2)) || \
+	defined(MOFED_MAJOR) 
 	cm_id = rdma_create_id(isert_cm_evt_handler, portal, RDMA_PS_TCP,
 			       IB_QPT_RC);
 #else


### PR DESCRIPTION
Fix build for iscsi-isert & srpt in RHEL/Centos 7.3 kernel >= 3.10.0-514.2.2