### PR TITLE
Use designated initializer for sys_alloc_fns

### DIFF
--- a/scst/src/scst_mem.c
+++ b/scst/src/scst_mem.c
@@ -1253,7 +1253,8 @@ struct scatterlist *scst_alloc_sg(int size, gfp_t gfp_mask, int *count)
 	struct scatterlist *res;
 	int pages = PAGE_ALIGN(size) >> PAGE_SHIFT;
 	struct sgv_pool_alloc_fns sys_alloc_fns = {
-		sgv_alloc_sys_pages, sgv_free_sys_sg_entries };
+		.alloc_pages_fn = sgv_alloc_sys_pages,
+		.free_pages_fn = sgv_free_sys_sg_entries };
 	int no_fail = ((gfp_mask & __GFP_NOFAIL) == __GFP_NOFAIL);
 	int cnt;
 


### PR DESCRIPTION
Designated initializers are required for GCC to safely implement
RANDSTRUCT, a GCC plugin pulled from the Grsecurity patch set
upstream ~2017.

Fix the compile error caused by implementation of sys_alloc_fns
by rewriting the struct with designated members.