### PR TITLE
iscsi-scst: remove unnecessary %s format modifiers

### DIFF
--- a/iscsi-scst/kernel/config.c
+++ b/iscsi-scst/kernel/config.c
@@ -59,16 +59,16 @@ static ssize_t iscsi_open_state_show(struct kobject *kobj,
 {
 	switch (ctr_open_state) {
 	case ISCSI_CTR_OPEN_STATE_CLOSED:
-		sprintf(buf, "%s\n", "closed");
+		sprintf(buf, "closed\n");
 		break;
 	case ISCSI_CTR_OPEN_STATE_OPEN:
-		sprintf(buf, "%s\n", "open");
+		sprintf(buf, "open\n");
 		break;
 	case ISCSI_CTR_OPEN_STATE_CLOSING:
-		sprintf(buf, "%s\n", "closing");
+		sprintf(buf, "closing\n");
 		break;
 	default:
-		sprintf(buf, "%s\n", "unknown");
+		sprintf(buf, "unknown\n");
 		break;
 	}
 

--- a/iscsi-scst/kernel/conn.c
+++ b/iscsi-scst/kernel/conn.c
@@ -39,7 +39,7 @@ static int print_conn_state(char *p, size_t size, struct iscsi_conn *conn)
 	int pos = 0;
 
 	if (conn->closing) {
-		pos += scnprintf(p, size, "%s", "closing");
+		pos += scnprintf(p, size, "closing");
 		goto out;
 	}
 

--- a/iscsi-scst/kernel/param.c
+++ b/iscsi-scst/kernel/param.c
@@ -66,14 +66,14 @@ const char *iscsi_get_digest_name(int val, char *res)
 	int pos = 0;
 
 	if (val & DIGEST_NONE)
-		pos = sprintf(&res[pos], "%s", "None");
+		pos = sprintf(&res[pos], "None");
 
 	if (val & DIGEST_CRC32C)
 		pos += sprintf(&res[pos], "%s%s", (pos != 0) ? ", " : "",
 			"CRC32C");
 
 	if (pos == 0)
-		sprintf(&res[pos], "%s", "Unknown");
+		sprintf(&res[pos], "Unknown");
 
 	return res;
 }

--- a/iscsi-scst/usr/event.c
+++ b/iscsi-scst/usr/event.c
@@ -624,7 +624,7 @@ static int handle_e_get_attr_value(int fd, const struct iscsi_kern_event *event)
 				isns_access_control ? ISCSI_ISNS_SYSFS_ACCESS_CONTROL_ENABLED : "");
 			add_key_mark(res_str, sizeof(res_str), 0);
 		} else
-			snprintf(res_str, sizeof(res_str), "%s\n", "");
+			snprintf(res_str, sizeof(res_str), "\n");
 	} else if (strcasecmp(ISCSI_ISNS_ENTITY_ATTR_NAME, pp) == 0)	{
 		if (target != NULL) {
 			log_error("Not NULL target %s for global attribute %s",

--- a/iscsi-scst/usr/param.c
+++ b/iscsi-scst/usr/param.c
@@ -181,7 +181,7 @@ static int digest_val_to_str(unsigned int val, char *str, int len)
 
 	if (val & DIGEST_NONE) {
 		len -= pos;
-		pos = snprintf(&str[pos], len, "%s", "None");
+		pos = snprintf(&str[pos], len, "None");
 	}
 
 	if (pos >= len)
@@ -197,7 +197,7 @@ static int digest_val_to_str(unsigned int val, char *str, int len)
 		goto out;
 
 	if (pos == 0)
-		pos = snprintf(&str[0], len, "%s", "Unknown");
+		pos = snprintf(&str[0], len, "Unknown");
 
 out:
 	return 0;


### PR DESCRIPTION
Just something I noted upon introspection :)

FWIW, I think there can be a lot more similar cleanups done with TRACE macros, however this would require to modify them so they can accept just one argument. I'll leave that to the reader :) The current cleanup was fully automated with `ack` and [`sed_perl`](https://github.com/Hi-Angel/dotfiles/blob/6a56f04f7c5c6b70e72bbaab3c8edb87e1507336/.zshrc#L109)