### PR TITLE
iscsi-scst: add a hint what to look for to fix the error

### DIFF
--- a/iscsi-scst/kernel/config.c
+++ b/iscsi-scst/kernel/config.c
@@ -59,16 +59,16 @@ static ssize_t iscsi_open_state_show(struct kobject *kobj,
 {
 	switch (ctr_open_state) {
 	case ISCSI_CTR_OPEN_STATE_CLOSED:
-		sprintf(buf, "%s\n", "closed");
+		sprintf(buf, "closed\n");
 		break;
 	case ISCSI_CTR_OPEN_STATE_OPEN:
-		sprintf(buf, "%s\n", "open");
+		sprintf(buf, "open\n");
 		break;
 	case ISCSI_CTR_OPEN_STATE_CLOSING:
-		sprintf(buf, "%s\n", "closing");
+		sprintf(buf, "closing\n");
 		break;
 	default:
-		sprintf(buf, "%s\n", "unknown");
+		sprintf(buf, "unknown\n");
 		break;
 	}
 

--- a/iscsi-scst/kernel/conn.c
+++ b/iscsi-scst/kernel/conn.c
@@ -39,7 +39,7 @@ static int print_conn_state(char *p, size_t size, struct iscsi_conn *conn)
 	int pos = 0;
 
 	if (conn->closing) {
-		pos += scnprintf(p, size, "%s", "closing");
+		pos += scnprintf(p, size, "closing");
 		goto out;
 	}
 

--- a/iscsi-scst/kernel/param.c
+++ b/iscsi-scst/kernel/param.c
@@ -66,14 +66,14 @@ const char *iscsi_get_digest_name(int val, char *res)
 	int pos = 0;
 
 	if (val & DIGEST_NONE)
-		pos = sprintf(&res[pos], "%s", "None");
+		pos = sprintf(&res[pos], "None");
 
 	if (val & DIGEST_CRC32C)
 		pos += sprintf(&res[pos], "%s%s", (pos != 0) ? ", " : "",
 			"CRC32C");
 
 	if (pos == 0)
-		sprintf(&res[pos], "%s", "Unknown");
+		sprintf(&res[pos], "Unknown");
 
 	return res;
 }

--- a/iscsi-scst/kernel/target.c
+++ b/iscsi-scst/kernel/target.c
@@ -435,7 +435,7 @@ ssize_t iscsi_sysfs_send_event(uint32_t tid, enum iscsi_kern_event_code code,
 	TRACE_ENTRY();
 
 	if (ctr_open_state != ISCSI_CTR_OPEN_STATE_OPEN) {
-		PRINT_ERROR("%s", "User space process not connected");
+		PRINT_ERROR("%s", "User space process not connected (perhaps is iscsi-scstd not running?)");
 		res = -EPERM;
 		goto out;
 	}
@@ -627,4 +627,3 @@ const struct attribute *iscsi_acg_attrs[] = {
 	&iscsi_acg_attr_sess_dedicated_threads.attr,
 	NULL,
 };
-

--- a/iscsi-scst/usr/event.c
+++ b/iscsi-scst/usr/event.c
@@ -624,7 +624,7 @@ static int handle_e_get_attr_value(int fd, const struct iscsi_kern_event *event)
 				isns_access_control ? ISCSI_ISNS_SYSFS_ACCESS_CONTROL_ENABLED : "");
 			add_key_mark(res_str, sizeof(res_str), 0);
 		} else
-			snprintf(res_str, sizeof(res_str), "%s\n", "");
+			snprintf(res_str, sizeof(res_str), "\n");
 	} else if (strcasecmp(ISCSI_ISNS_ENTITY_ATTR_NAME, pp) == 0)	{
 		if (target != NULL) {
 			log_error("Not NULL target %s for global attribute %s",

--- a/iscsi-scst/usr/param.c
+++ b/iscsi-scst/usr/param.c
@@ -181,7 +181,7 @@ static int digest_val_to_str(unsigned int val, char *str, int len)
 
 	if (val & DIGEST_NONE) {
 		len -= pos;
-		pos = snprintf(&str[pos], len, "%s", "None");
+		pos = snprintf(&str[pos], len, "None");
 	}
 
 	if (pos >= len)
@@ -197,7 +197,7 @@ static int digest_val_to_str(unsigned int val, char *str, int len)
 		goto out;
 
 	if (pos == 0)
-		pos = snprintf(&str[0], len, "%s", "Unknown");
+		pos = snprintf(&str[0], len, "Unknown");
 
 out:
 	return 0;

--- a/scst/src/dev_handlers/scst_user.c
+++ b/scst/src/dev_handlers/scst_user.c
@@ -2356,7 +2356,7 @@ out:
 }
 
 static int dev_user_reply_get_multi(struct file *file,
-				    struct scst_user_get_multi __user* gm)
+				    struct scst_user_get_multi __user *gm)
 {
 	int res = 0, rc;
 	struct scst_user_dev *dev = file->private_data;


### PR DESCRIPTION
Recently I spent about a day trying to understand why I was getting the error *(hw problems in part contributed to the confusion)*. I did see in 2012 someone mentioned that to fix this error one should launch `iscsi-scstd` service. However there is no service with that name, so I deemed that to be outdated information.

Turns out, it is a binary, not a service, and it does need to be running for scst to work. Let's potentially save someone's time in the future by mentioning that nuance in the error message