### PR TITLE
Debian package creation fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -387,11 +387,7 @@ dpkg: ../scst_$(VERSION).orig.tar.gz
 	else								\
 	  buildopts+=(-j4);						\
 	fi &&								\
-	if false; then							\
-	  dpkg-buildpackage "$${buildopts[@]}";				\
-	else								\
-	  debuild "$${buildopts[@]}" --lintian-opts --profile debian;	\
-	fi &&								\
+	debuild "$${buildopts[@]}" --lintian-opts --profile debian &&   \
 	mkdir -p dpkg &&						\
 	for f in "$${output_files[@]}" ../scst_$(VERSION).orig.tar.[gx]z; do\
 		mv $$f dpkg || true;					\

--- a/Makefile
+++ b/Makefile
@@ -391,7 +391,7 @@ dpkg: ../scst_$(VERSION).orig.tar.gz
 	else								\
 	  buildopts+=(-j4);						\
 	fi &&								\
-	DEB_KVER_SET=$(KVER) DEB_KDIR_SET=$(KDIR) debuild "$${buildopts[@]}" --lintian-opts --profile debian && \
+	DEB_CC_SET="$(CC)" DEB_KVER_SET=$(KVER) DEB_KDIR_SET=$(KDIR) debuild "$${buildopts[@]}" --lintian-opts --profile debian && \
 	mkdir -p dpkg &&						\
 	for f in "$${output_files[@]}" ../scst_$(VERSION).orig.tar.[gx]z; do\
 		mv $$f dpkg || true;					\

--- a/Makefile
+++ b/Makefile
@@ -367,6 +367,8 @@ dpkg: ../scst_$(VERSION).orig.tar.gz
 	[ -z "$$DEBFULLNAME" ] || export DEBFULLNAME="Bart Van Assche" &&\
 	sed 's/%{scst_version}/$(VERSION)/'				\
 	  <debian/scst.dkms.in >debian/scst.dkms &&			\
+	sed 's/%{KVER}/$(KVER)/'				\
+	  <debian/scst.preinst.in >debian/scst.preinst &&			\
 	output_files=(							\
 		../*_$(VERSION)-$(DEBIAN_REVISION)_*.deb		\
 		../*_$(VERSION)-$(DEBIAN_REVISION)_*.ddeb		\

--- a/Makefile
+++ b/Makefile
@@ -387,7 +387,7 @@ dpkg: ../scst_$(VERSION).orig.tar.gz
 	else								\
 	  buildopts+=(-j4);						\
 	fi &&								\
-	debuild "$${buildopts[@]}" --lintian-opts --profile debian &&   \
+	DEB_KVER_SET=$(KVER) DEB_KDIR_SET=$(KDIR) debuild "$${buildopts[@]}" --lintian-opts --profile debian && \
 	mkdir -p dpkg &&						\
 	for f in "$${output_files[@]}" ../scst_$(VERSION).orig.tar.[gx]z; do\
 		mv $$f dpkg || true;					\

--- a/Makefile
+++ b/Makefile
@@ -369,6 +369,8 @@ dpkg: ../scst_$(VERSION).orig.tar.gz
 	  <debian/scst.dkms.in >debian/scst.dkms &&			\
 	sed 's/%{KVER}/$(KVER)/'				\
 	  <debian/scst.preinst.in >debian/scst.preinst &&			\
+	sed 's/%{KVER}/$(KVER)/'				\
+	  <debian/scst.postinst.in >debian/scst.postinst &&			\
 	output_files=(							\
 		../*_$(VERSION)-$(DEBIAN_REVISION)_*.deb		\
 		../*_$(VERSION)-$(DEBIAN_REVISION)_*.ddeb		\

--- a/debian/rules
+++ b/debian/rules
@@ -29,7 +29,8 @@ export KDIR=$(DEB_KDIR_SET)
 clean:
 	dh_testdir &&							\
 	dh_prep -Xqla_isp/TAGS -Xdebian/changelog &&			\
-	scripts/clean-source-tree -x debian/changelog -x debian/compat -x debian/scst.preinst
+	scripts/clean-source-tree -x debian/changelog -x debian/compat -x debian/scst.preinst \
+	    -x debian/scst.postinst
 
 build:
 	make 2release &&						\

--- a/debian/rules
+++ b/debian/rules
@@ -29,7 +29,7 @@ export KDIR=$(DEB_KDIR_SET)
 clean:
 	dh_testdir &&							\
 	dh_prep -Xqla_isp/TAGS -Xdebian/changelog &&			\
-	scripts/clean-source-tree -x debian/changelog -x debian/compat
+	scripts/clean-source-tree -x debian/changelog -x debian/compat -x debian/scst.preinst
 
 build:
 	make 2release &&						\

--- a/debian/rules
+++ b/debian/rules
@@ -21,6 +21,7 @@ VERSION:=$(shell head -n1 debian/changelog | sed 's/.*(\([0-9.]*\).*).*/\1/')
 # an intermediary. Also, export variables for sub-makes to be able to see them.
 export KVER=$(DEB_KVER_SET)
 export KDIR=$(DEB_KDIR_SET)
+export CC=$(DEB_CC_SET)
 
 %:
 	echo "*** dh $@ ***"

--- a/debian/rules
+++ b/debian/rules
@@ -17,6 +17,11 @@ SUBDIRS=scst fcst iscsi-scst qla2x00t/qla2x00-target scst_local scstadmin srpt
 DESTDIR=$(CURDIR)/debian/tmp
 VERSION:=$(shell head -n1 debian/changelog | sed 's/.*(\([0-9.]*\).*).*/\1/')
 
+# rules won't see variables unless they're using DEB_foo_SET syntax. So use that as
+# an intermediary. Also, export variables for sub-makes to be able to see them.
+export KVER=$(DEB_KVER_SET)
+export KDIR=$(DEB_KDIR_SET)
+
 %:
 	echo "*** dh $@ ***"
 	dh $@

--- a/debian/scst.postinst.in
+++ b/debian/scst.postinst.in
@@ -23,7 +23,7 @@ case "$1" in
 	mkdir -p /var/lib/scst/dif_tags
 	mkdir -p /var/lib/scst/pr
 	mkdir -p /var/lib/scst/vdev_mode_pages
-	depmod;;
+	depmod "%{KVER}";;
 
     abort-upgrade|abort-remove|abort-deconfigure)
 	;;

--- a/debian/scst.preinst.in
+++ b/debian/scst.preinst.in
@@ -17,7 +17,7 @@ set -e
 case "$1" in
     install)
 	# Remove any existing ib_srpt.ko kernel modules
-	find "/lib/modules/$(uname -r)" -name ib_srpt.ko -exec rm {} \;
+	find "/lib/modules/%{KVER}" -name ib_srpt.ko -exec rm {} \;
 	# Remove files installed by "make install"
 	rm -f /usr/local/man/man5/iscsi-scstd.conf.5
 	rm -f /usr/local/man/man8/iscsi-scst-adm.8


### PR DESCRIPTION
This series represents a number of fixes for the non-dkms scst package. 2nd commit fixes a problem where the user-set KVER and KDIR were ignored, which may silently result in invalid package content *(as scst would get build against the running kernel instead)*. 3 and 4 commits fix the problem that `preinst` and `postinst` scripts of the package were using the wrong kernel.

And 1 and 5 commits are just small cleanups; the 5th commit in particular would allow one for example use `ccache` to speed up the build.

The problems being fixed can be seen in particular while building it inside a container.