### PR TITLE
Makefile: add ability to enable qla-32gbit target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,11 +37,22 @@ ifdef KDIR
      endif
 endif
 
+ifdef QLA_32GBIT
+    ifneq ($(QLA_32GBIT),no)
+        QLA_INI_DIR=qla2x00t-32gbit
+        QLA_DIR=qla2x00t-32gbit/qla2x00-target
+    else
+        QLA_INI_DIR=qla2x00t
+        QLA_DIR=qla2x00t/qla2x00-target
+    endif
+else
+    QLA_INI_DIR=qla2x00t
+    QLA_DIR=qla2x00t/qla2x00-target
+endif
+
 SCST_DIR=scst
 DOC_DIR=doc
 SCSTADM_DIR=scstadmin
-QLA_INI_DIR=qla2x00t
-QLA_DIR=qla2x00t/qla2x00-target
 USR_DIR=usr
 SRP_DIR=srpt
 SCST_LOCAL_DIR=scst_local
@@ -395,7 +406,8 @@ dpkg: ../scst_$(VERSION).orig.tar.gz
 	else								\
 	  buildopts+=(-j4);						\
 	fi &&								\
-	DEB_CC_SET="$(CC)" DEB_KVER_SET=$(KVER) DEB_KDIR_SET=$(KDIR) debuild "$${buildopts[@]}" --lintian-opts --profile debian && \
+	DEB_CC_SET="$(CC)" DEB_KVER_SET=$(KVER) DEB_KDIR_SET=$(KDIR) DEB_QLA_DIR_SET=$(QLA_DIR) \
+	   DEB_QLA_INI_DIR_SET=$(QLA_INI_DIR) debuild "$${buildopts[@]}" --lintian-opts --profile debian && \
 	mkdir -p dpkg &&						\
 	for f in "$${output_files[@]}" ../scst_$(VERSION).orig.tar.[gx]z; do\
 		mv $$f dpkg || true;					\

--- a/Makefile
+++ b/Makefile
@@ -37,17 +37,12 @@ ifdef KDIR
      endif
 endif
 
-ifdef QLA_32GBIT
-    ifneq ($(QLA_32GBIT),no)
-        QLA_INI_DIR=qla2x00t-32gbit
-        QLA_DIR=qla2x00t-32gbit/qla2x00-target
-    else
-        QLA_INI_DIR=qla2x00t
-        QLA_DIR=qla2x00t/qla2x00-target
-    endif
-else
+ifeq ($(QLA_32GBIT),no)
     QLA_INI_DIR=qla2x00t
     QLA_DIR=qla2x00t/qla2x00-target
+else
+    QLA_INI_DIR=qla2x00t-32gbit
+    QLA_DIR=qla2x00t-32gbit/qla2x00-target
 endif
 
 SCST_DIR=scst

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ setups.
 
 There is also a newer driver that supports 32 Gb/s FC in the qla2x00t-32gbit
 directory. That driver has not yet reached the same maturity level as the
-old qla2x00t driver.
+old qla2x00t driver. It can be enabled by setting `QLA_32GBIT=y` variable
+while compiling.
 
 Vladislav Bolkhovitin <vst@vlnb.net>, http://scst.sourceforge.net

--- a/README.md
+++ b/README.md
@@ -17,14 +17,13 @@ file.
 
 ## QLogic target driver
 
-Two QLogic target drivers are included in the SCST project. The driver in
-the qla2x00t directory is a very stable driver that supports up to 16 Gb/s
-adapters. It is very stable, well tested and actively used in many production
-setups.
+Two QLogic target drivers are included in the SCST project.
 
-There is also a newer driver that supports 32 Gb/s FC in the qla2x00t-32gbit
-directory. That driver has not yet reached the same maturity level as the
-old qla2x00t driver. It can be enabled by setting `QLA_32GBIT=y` variable
-while compiling.
+The default driver is located in qla2x00t-32gbit directory and it supports up
+to 32 Gb/s FC. It is the newer one.
+
+May anyone wish to switch back to the older driver that only supported up to
+16 Gb/s adapters, it is located in qla2x00t directory. To make use of the
+older driver build scst with environment variable `QLA_32GBIT=no` set.
 
 Vladislav Bolkhovitin <vst@vlnb.net>, http://scst.sourceforge.net

--- a/debian/rules
+++ b/debian/rules
@@ -13,15 +13,17 @@ export DH_VERBOSE = 1
 # package maintainers to append LDFLAGS
 #export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
 
-SUBDIRS=scst $(shell grep -qw '^CONFIG_LIBFC' /boot/config-$(uname -r) && echo fcst) iscsi-scst qla2x00t/qla2x00-target scst_local scstadmin srpt
-DESTDIR=$(CURDIR)/debian/tmp
-VERSION:=$(shell head -n1 debian/changelog | sed 's/.*(\([0-9.]*\).*).*/\1/')
-
 # rules won't see variables unless they're using DEB_foo_SET syntax. So use that as
 # an intermediary. Also, export variables for sub-makes to be able to see them.
 export KVER=$(DEB_KVER_SET)
 export KDIR=$(DEB_KDIR_SET)
 export CC=$(DEB_CC_SET)
+export QLA_DIR=$(DEB_QLA_DIR_SET)
+export QLA_INI_DIR=$(DEB_QLA_INI_DIR_SET)
+
+SUBDIRS=scst $(shell grep -qw '^CONFIG_LIBFC' /boot/config-$(uname -r) && echo fcst) iscsi-scst $(QLA_DIR) scst_local scstadmin srpt
+DESTDIR=$(CURDIR)/debian/tmp
+VERSION:=$(shell head -n1 debian/changelog | sed 's/.*(\([0-9.]*\).*).*/\1/')
 
 %:
 	echo "*** dh $@ ***"
@@ -41,7 +43,7 @@ build:
 	{								\
 		echo dkms.conf &&					\
 		echo Makefile &&					\
-		for d in fcst iscsi-scst qla2x00t scst scst_local srpt; do\
+		for d in fcst iscsi-scst $(QLA_INI_DIR) scst scst_local srpt; do\
 			echo $$d;					\
 		done;							\
 	} | sed "s,^,usr/src/scst-$(VERSION)/," >debian/scst-dkms.install
@@ -75,7 +77,7 @@ install:
 	cp debian/scst.dkms						\
 		$(DESTDIR)/usr/src/scst-$(VERSION)/dkms.conf &&		\
 	scripts/list-source-files |					\
-	grep -E '^Makefile$$|^(fcst|iscsi-scst|qla2x00t|scst|scst_local|srpt)/'|\
+	grep -E '^Makefile$$|^(fcst|iscsi-scst|$(QLA_INI_DIR)|scst|scst_local|srpt)/'|\
 	tar -T- -cf- |							\
 	tar -C $(DESTDIR)/usr/src/scst-$(VERSION) -xf- &&		\
 	find $(DESTDIR) -type f -print0 | xargs -0 -r chmod 0644 &&	\


### PR DESCRIPTION
Although qla-32gbit is mentioned in the README, but there wasn't really a
way to enable it sans editing the code.

This commit adds an ability to enable the driver by passing
`QLA_32GBIT=y` variable at build time.

-----------

Worth noting, apparently Makefile build system doesn't support combining `ifdef` with `ifeq`s by using some `and`-like syntax, so I had to duplicate the `QLA_INI_DIR=qla2x00t` assignment into two different branches. Better ideas are welcome.