### PR TITLE
Reenable block_shift calculation for tapes

### DIFF
--- a/scst/src/dev_handlers/scst_tape.c
+++ b/scst/src/dev_handlers/scst_tape.c
@@ -145,7 +145,7 @@ static int tape_attach(struct scst_device *dev)
 	}
 
 	dev->block_size = TAPE_DEF_BLOCK_SIZE;
-	dev->block_shift = -1; /* not used */
+	dev->block_shift = scst_calc_block_shift(dev->block_size);
 
 	buffer = kmalloc(buffer_size, GFP_KERNEL);
 	if (!buffer) {
@@ -203,7 +203,7 @@ static int tape_attach(struct scst_device *dev)
 		res = -ENODEV;
 		goto out_free_buf;
 	}
-	dev->block_shift = -1; /* not used */
+	dev->block_shift = scst_calc_block_shift(dev->block_size);
 
 obtain:
 	res = scst_obtain_device_parameters(dev, NULL);
@@ -250,7 +250,7 @@ static void tape_set_block_size(struct scst_cmd *cmd, int block_size)
 	 * there are existing commands.
 	 */
 	dev->block_size = block_size;
-	dev->block_shift = -1; /* not used */
+	dev->block_shift = scst_calc_block_shift(dev->block_size);
 	return;
 }
 

--- a/scst/src/scst_lib.c
+++ b/scst/src/scst_lib.c
@@ -12470,6 +12470,8 @@ int scst_tape_generic_parse(struct scst_cmd *cmd)
 				shift_left_overflows(cmd->data_len, block_shift) ||
 				shift_left_overflows(cmd->out_bufflen, block_shift);
 
+		EXTRACHECKS_BUG_ON(block_shift < 0);
+		
 		BUILD_BUG_ON(sizeof(cmd->bufflen) != 4);
 		BUILD_BUG_ON(sizeof(cmd->out_bufflen) != 4);
 		if (unlikely(overflow)) {


### PR DESCRIPTION
I noticed this while trying to backup data to a tape library using SCST in iSCSI pass through mode:

Commit 94a84ad introduced an optimization in `scst_tape_generic_parse`, that relies on `block_shift` being set for the target device of the command. (e.g 16 for a block size of 65536)

However the calculation of `block_shift` was disabled for tape devices way back in commit 0043f51.

This results in a constant value of `-1` for `block_shift`, which in turn let's `scst_tape_generic_parse` error out valid commands, preventing them from even being passed to the SCSI Mid-Layer.

A simple fix would be to re-introduce the `block_shift` calculation that was done up to commit 0043f51.
I hope I got all the right places :) This patch worked for me.

Fixes: 0043f51 ("block shift cleanups and fixes")