### PR TITLE
FIX: Cannot add inactive block-device with unexistent filename

### DIFF
--- a/scst/src/dev_handlers/scst_vdisk.c
+++ b/scst/src/dev_handlers/scst_vdisk.c
@@ -1347,6 +1347,12 @@ static int vdisk_open_fd(struct scst_vdisk_dev *virt_dev, bool read_only)
 		virt_dev->bdev = blkdev_get_by_path(virt_dev->filename,
 					virt_dev->bdev_mode, (void *)__func__);
 		res = IS_ERR(virt_dev->bdev) ? PTR_ERR(virt_dev->bdev) : 0;
+		if ((!virt_dev->dev_active) && (res == -ENOENT))
+		{
+			TRACE_MGMT_DBG("Skip opening for not active dev %s",
+			       virt_dev->dev->virt_name);
+			res = -EMEDIUMTYPE;
+		}
 	} else {
 		virt_dev->fd = vdev_open_fd(virt_dev, virt_dev->filename,
 					    read_only);


### PR DESCRIPTION
You can not add inactive block-device with nonexistent filename now.
This happened due to the transition to blkdev_get_by_path in the vdisk_open_fd function.
And there is no condition of returning -ENOENT of the function blkdev_get_by_path.
There was a condition that uses virt_dev->active parameter in function vdev_open_fd before commit df4c250b8db54e6eec235d7104c28f827f501551, and this allowed us to create any block-device with nonexistent filename with 'active=0'.
